### PR TITLE
Add Support for Smart Plugs with Energy Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ If you happen to own a device that is not on this list, feel free to open an iss
 - <a href='https://www.amazon.com/gp/product/B07PFS7RY5'>Luntak</a>
 - <a href='https://www.amazon.com/gp/product/B07H36GG8L'>Nephalae</a>
 - <a href='https://www.amazon.com/gp/product/B07HHYK14L'>Manzoku</a>
+- <a href='https://www.amazon.de/gp/product/B07S4C4488/'>AISIRER</a>
 
 ## Dimmers
 - <a href='https://www.amazon.com/dp/B07RBQX7BR'>Lumary Dimmer Switch L-DS100</a> (config: `{"maxlevel":100}`)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ For plugs with n>1 sockets, use config `{"sockets":n}`
 - <a href='https://www.amazon.com/dp/B077S69421'>W-US002 smart socket</a>
 - <a href='https://www.amazon.de/gp/product/B079L6GVNF/'>Yuntong Smart relay</a>
 
+## Plugs with Energy Monitoring
+- <a href='https://www.amazon.de/gp/product/B0777BWS1P/'>Gosund Smart Plug / Socket WiFi</a>
+
 ## Plugs with night light
 - <a href='https://aracky.com/products/wifi-smart-plug-in-night-light-led-jackyled-wi-fi-smart-alexa-plug-double-outlet-extender-adjustable-brightest-or-dim-light-for-hallways-kids-dogs-work-with-echo-google-home-assistant-and-ifttt-2-pack'>JACKYLED plug with 2 sockets and night light</a> (config: `{"dps":{"brightness":103},"sockets":2,"minbrightness":1,"maxbrightness":255}`)
 

--- a/lib/adapter.js
+++ b/lib/adapter.js
@@ -8,6 +8,7 @@ const DimmerDevice = require('./devices/dimmer-device');
 const FireplaceHeaterDevice = require('./devices/fireplace-heater-device');
 const LightDevice = require('./devices/light-device');
 const PlugDevice = require('./devices/plug-device');
+const PlugEnergyMonitorDevice = require('./devices/plug-energy-monitor-device');
 const PlugNightlightDevice = require('./devices/plug-nightlight-device');
 const SwitchDevice = require('./devices/switch-device');
 const GenericDevice = require('./devices/generic-device');
@@ -56,6 +57,9 @@ class TuyaAdapter extends Adapter {
             break;
           case 'Plug':
             d = new PlugDevice(this, conf, cid);
+            break;
+          case 'Plug with energy monitoring':
+            d = new PlugEnergyMonitorDevice(this, conf, cid);
             break;
           case 'Plug with night light':
             d = new PlugNightlightDevice(this, conf, cid);

--- a/lib/devices/plug-energy-monitor-device.js
+++ b/lib/devices/plug-energy-monitor-device.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const TuyaDevice = require('./tuya-device');
+const PowerProperty = require('../properties/power-property');
+const ReadOnlyNumberProperty = require('../properties/read-only-number-property');
+
+class PlugEnergyMonitorDevice extends TuyaDevice {
+  constructor(adapter, cnf, cid) {
+    super(adapter, cnf, cid);
+
+    if (!('sockets' in this.ownconf)) {
+      this.ownconf.sockets = 1;
+    }
+
+    if (this.ownconf.sockets > 1)
+      this.name = cnf.name&&cnf.name!='' ? cnf.name : `Plug with energy monitoring`;
+    this['@type'] = ['SmartPlug'];
+
+    if (this.ownconf.sockets == 1){
+      this.addProperty(new PowerProperty(this, {dps: this.ownconf.dps.on, default_dps: 1}));
+      this.addProperty(new ReadOnlyNumberProperty(this, "unknown", {dps: this.ownconf.dps.unknown, default_dps: 9}));
+      this.addProperty(new ReadOnlyNumberProperty(this, "Electric Current in mA", {dps: this.ownconf.dps.current, default_dps: 18}));
+      this.addProperty(new ReadOnlyNumberProperty(this, "Electric Power in Watt/10", {dps: this.ownconf.dps.powerwatts, default_dps: 19}));
+      this.addProperty(new ReadOnlyNumberProperty(this, "Electric Potential in Volt/10", {dps: this.ownconf.dps.potential, default_dps: 20}));
+    }
+  }
+}
+
+module.exports = PlugEnergyMonitorDevice;

--- a/lib/devices/plug-energy-monitor-device.js
+++ b/lib/devices/plug-energy-monitor-device.js
@@ -16,12 +16,12 @@ class PlugEnergyMonitorDevice extends TuyaDevice {
       this.name = cnf.name&&cnf.name!='' ? cnf.name : `Plug with energy monitoring`;
     this['@type'] = ['SmartPlug'];
 
-    if (this.ownconf.sockets == 1) {
+    if (this.ownconf.sockets == 1){
       this.addProperty(new PowerProperty(this, {dps: this.ownconf.dps.on, default_dps: 1}));
-      this.addProperty(new ReadOnlyNumberProperty(this, 'unknown', {dps: this.ownconf.dps.unknown, default_dps: 9}));
-      this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Current in mA', {dps: this.ownconf.dps.current, default_dps: 18}));
-      this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Power in Watt*10', {dps: this.ownconf.dps.powerwatts, default_dps: 19}));
-      this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Potential in Volt*10', {dps: this.ownconf.dps.potential, default_dps: 20}));
+      this.addProperty(new ReadOnlyNumberProperty(this, "unknown", {dps: this.ownconf.dps.unknown, default_dps: 9}));
+      this.addProperty(new ReadOnlyNumberProperty(this, "current", {dps: this.ownconf.dps.current, default_dps: 18}));
+      this.addProperty(new ReadOnlyNumberProperty(this, "power", {dps: this.ownconf.dps.power, default_dps: 19}));
+      this.addProperty(new ReadOnlyNumberProperty(this, "potential", {dps: this.ownconf.dps.potential, default_dps: 20}));
     }
   }
 }

--- a/lib/devices/plug-energy-monitor-device.js
+++ b/lib/devices/plug-energy-monitor-device.js
@@ -2,7 +2,7 @@
 
 const TuyaDevice = require('./tuya-device');
 const PowerProperty = require('../properties/power-property');
-const ReadOnlyNumberProperty = require('../properties/read-only-number-property');
+const NumberProperty = require('../properties/number-property');
 
 class PlugEnergyMonitorDevice extends TuyaDevice {
   constructor(adapter, cnf, cid) {
@@ -18,10 +18,10 @@ class PlugEnergyMonitorDevice extends TuyaDevice {
 
     if (this.ownconf.sockets == 1) {
       this.addProperty(new PowerProperty(this, {dps: this.ownconf.dps.on, default_dps: 1}));
-      this.addProperty(new ReadOnlyNumberProperty(this, 'unknown', {dps: this.ownconf.dps.unknown, default_dps: 9}));
-      this.addProperty(new ReadOnlyNumberProperty(this, 'currentInmA', {dps: this.ownconf.dps.currentInmA, default_dps: 18}));
-      this.addProperty(new ReadOnlyNumberProperty(this, 'power', {dps: this.ownconf.dps.power, default_dps: 19}));
-      this.addProperty(new ReadOnlyNumberProperty(this, 'potential', {dps: this.ownconf.dps.potential, default_dps: 20}));
+      this.addProperty(new NumberProperty(this, {dps: this.ownconf.dps.unknown, default_dps: 9}));
+      this.addProperty(new NumberProperty(this, {dps: this.ownconf.dps.currentInmA, default_dps: 18}));
+      this.addProperty(new NumberProperty(this, {dps: this.ownconf.dps.power, default_dps: 19}));
+      this.addProperty(new NumberProperty(this, {dps: this.ownconf.dps.potential, default_dps: 20}));
     }
   }
 }

--- a/lib/devices/plug-energy-monitor-device.js
+++ b/lib/devices/plug-energy-monitor-device.js
@@ -16,12 +16,12 @@ class PlugEnergyMonitorDevice extends TuyaDevice {
       this.name = cnf.name&&cnf.name!='' ? cnf.name : `Plug with energy monitoring`;
     this['@type'] = ['SmartPlug'];
 
-    if (this.ownconf.sockets == 1){
+    if (this.ownconf.sockets == 1) {
       this.addProperty(new PowerProperty(this, {dps: this.ownconf.dps.on, default_dps: 1}));
-      this.addProperty(new ReadOnlyNumberProperty(this, "unknown", {dps: this.ownconf.dps.unknown, default_dps: 9}));
-      this.addProperty(new ReadOnlyNumberProperty(this, "current", {dps: this.ownconf.dps.current, default_dps: 18}));
-      this.addProperty(new ReadOnlyNumberProperty(this, "power", {dps: this.ownconf.dps.power, default_dps: 19}));
-      this.addProperty(new ReadOnlyNumberProperty(this, "potential", {dps: this.ownconf.dps.potential, default_dps: 20}));
+      this.addProperty(new ReadOnlyNumberProperty(this, 'unknown', {dps: this.ownconf.dps.unknown, default_dps: 9}));
+      this.addProperty(new ReadOnlyNumberProperty(this, 'currentInmA', {dps: this.ownconf.dps.currentInmA, default_dps: 18}));
+      this.addProperty(new ReadOnlyNumberProperty(this, 'power', {dps: this.ownconf.dps.power, default_dps: 19}));
+      this.addProperty(new ReadOnlyNumberProperty(this, 'potential', {dps: this.ownconf.dps.potential, default_dps: 20}));
     }
   }
 }

--- a/lib/devices/plug-energy-monitor-device.js
+++ b/lib/devices/plug-energy-monitor-device.js
@@ -16,12 +16,12 @@ class PlugEnergyMonitorDevice extends TuyaDevice {
       this.name = cnf.name&&cnf.name!='' ? cnf.name : `Plug with energy monitoring`;
     this['@type'] = ['SmartPlug'];
 
-    if (this.ownconf.sockets == 1){
+    if (this.ownconf.sockets == 1) {
       this.addProperty(new PowerProperty(this, {dps: this.ownconf.dps.on, default_dps: 1}));
-      this.addProperty(new ReadOnlyNumberProperty(this, "unknown", {dps: this.ownconf.dps.unknown, default_dps: 9}));
-      this.addProperty(new ReadOnlyNumberProperty(this, "Electric Current in mA", {dps: this.ownconf.dps.current, default_dps: 18}));
-      this.addProperty(new ReadOnlyNumberProperty(this, "Electric Power in Watt/10", {dps: this.ownconf.dps.powerwatts, default_dps: 19}));
-      this.addProperty(new ReadOnlyNumberProperty(this, "Electric Potential in Volt/10", {dps: this.ownconf.dps.potential, default_dps: 20}));
+      this.addProperty(new ReadOnlyNumberProperty(this, 'unknown', {dps: this.ownconf.dps.unknown, default_dps: 9}));
+      this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Current in mA', {dps: this.ownconf.dps.current, default_dps: 18}));
+      this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Power in Watt/10', {dps: this.ownconf.dps.powerwatts, default_dps: 19}));
+      this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Potential in Volt/10', {dps: this.ownconf.dps.potential, default_dps: 20}));
     }
   }
 }

--- a/lib/devices/plug-energy-monitor-device.js
+++ b/lib/devices/plug-energy-monitor-device.js
@@ -20,8 +20,8 @@ class PlugEnergyMonitorDevice extends TuyaDevice {
       this.addProperty(new PowerProperty(this, {dps: this.ownconf.dps.on, default_dps: 1}));
       this.addProperty(new ReadOnlyNumberProperty(this, 'unknown', {dps: this.ownconf.dps.unknown, default_dps: 9}));
       this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Current in mA', {dps: this.ownconf.dps.current, default_dps: 18}));
-      this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Power in Watt/10', {dps: this.ownconf.dps.powerwatts, default_dps: 19}));
-      this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Potential in Volt/10', {dps: this.ownconf.dps.potential, default_dps: 20}));
+      this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Power in Watt*10', {dps: this.ownconf.dps.powerwatts, default_dps: 19}));
+      this.addProperty(new ReadOnlyNumberProperty(this, 'Electric Potential in Volt*10', {dps: this.ownconf.dps.potential, default_dps: 20}));
     }
   }
 }

--- a/lib/properties/read-only-number-property.js
+++ b/lib/properties/read-only-number-property.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const TuyaProperty = require('./tuya-property');
+
+class ReadOnlyNumberProperty extends TuyaProperty {
+  constructor(device, name, cnf) {
+    super(device, name, {
+      label: cnf.name?cnf.name:cnf.dps,
+      type: 'number',
+      value: 0,
+    }, cnf);
+  }
+
+  update(value) {
+    super.update(value);
+    this.setCachedValueAndNotify(value);
+  }
+  
+  autodps(obj) {
+    return Object.keys(obj).find((x) => (typeof (obj[x]) === 'number'));
+  }
+}
+
+module.exports = ReadOnlyNumberProperty;

--- a/lib/properties/read-only-number-property.js
+++ b/lib/properties/read-only-number-property.js
@@ -15,7 +15,7 @@ class ReadOnlyNumberProperty extends TuyaProperty {
     super.update(value);
     this.setCachedValueAndNotify(value);
   }
-  
+
   autodps(obj) {
     return Object.keys(obj).find((x) => (typeof (obj[x]) === 'number'));
   }

--- a/manifest.json
+++ b/manifest.json
@@ -48,7 +48,7 @@
               "type": {
                 "title": "Type",
                 "type": "string",
-                "enum": ["Colour Light", "Dimmer", "Fireplace heater", "Light", "Plug", "Plug with night light", "Switch"]
+                "enum": ["Colour Light", "Dimmer", "Fireplace heater", "Light", "Plug", "Plug with energy monitoring", "Plug with night light", "Switch"]
               },
               "config": {
                 "title": "Configuration (usually needn't be changed manually)",


### PR DESCRIPTION
Support for Tuya Smart Plugs with Energy Monitoring. 
Tested with my Gosund Smart Plugs, which have the following DPS layouts: 

```
dps: {
    '1': false,  	//on/off
    '9': 0,       	//unknown/static 0
    '18': 0,	        //electric current (mA)
    '19': 0, 	        //electric power(watt*10)
    '20': 2303,         //electric potential(volt*10)
    '21': 1,            //static/unknown.....
    '22': 715,
    '23': 30333,
    '24': 20561,
    '25': 1010
  }
```
You can leave the configuration field empty, which then gets automatically set to:
`{"dps":{"on":1,"unknown":9,"Electric Current in mA":18,"Electric Power in Watt/10":19,"Electric Potential in Volt/10":20},"sockets":1}`