### PR TITLE
Remove autodps for Electric Monitoring Properties

### DIFF
--- a/lib/properties/plug-energy-monitor/current-monitor-property.js
+++ b/lib/properties/plug-energy-monitor/current-monitor-property.js
@@ -17,10 +17,6 @@ class CurrentMonitorProperty extends TuyaProperty {
     value = value/1000.0; //plug sends current in unit mA
     this.setCachedValueAndNotify(value);
   }
-
-  autodps(obj) {
-    return Object.keys(obj).find((x) => (typeof (obj[x]) === 'number'));
-  }
 }
 
 module.exports = CurrentMonitorProperty;

--- a/lib/properties/plug-energy-monitor/power-monitor-property.js
+++ b/lib/properties/plug-energy-monitor/power-monitor-property.js
@@ -17,10 +17,6 @@ class PowerMonitorProperty extends TuyaProperty {
     value = value/10.0; //plug sends power in unit Watt * 10
     this.setCachedValueAndNotify(value);
   }
-
-  autodps(obj) {
-    return Object.keys(obj).find((x) => (typeof (obj[x]) === 'number'));
-  }
 }
 
 module.exports = PowerMonitorProperty;

--- a/lib/properties/plug-energy-monitor/voltage-monitor-property.js
+++ b/lib/properties/plug-energy-monitor/voltage-monitor-property.js
@@ -17,10 +17,6 @@ class VoltageMonitorProperty extends TuyaProperty {
     value = value/10.0; //plug sends power in unit Volt * 10
     this.setCachedValueAndNotify(value);
   }
-
-  autodps(obj) {
-    return Object.keys(obj).find((x) => (typeof (obj[x]) === 'number'));
-  }
 }
 
 module.exports = VoltageMonitorProperty;


### PR DESCRIPTION
See: https://github.com/Galveston01/tuya-adapter/pull/13#discussion_r471173060 

Without autodps, the dps index now gets set correctly. I think it might be better to use the specified default dps index or a specific config instead of autodps.